### PR TITLE
feat(fmt): add deterministic pretty/ast formatter and CLI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /temp
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ This repository contains independent implementations that must agree byte-for-by
 
 - Reference implementation
 - Defines canonical truth
-- Full encoder, decoder, parser, and CLI
+- Full encoder, decoder, parser, formatter, and CLI
 - Golden vectors and Northstar enforcement
 
 ### JavaScript — `strata-js`
 
 - Parity implementation with Rust
-- Canonical encoding and hashing
+- Canonical encoding, hashing, and formatting
 - Shared golden vectors and CI enforcement
 - First-class DX APIs
 

--- a/strata-js/README.md
+++ b/strata-js/README.md
@@ -38,6 +38,7 @@ This package provides:
 - Safe decoder with explicit error semantics
 - Parser for Strata Text (`.st`)
 - Deterministic BLAKE3 hashing
+- Deterministic formatting (`fmt`)
 - CLI tooling (mirrors Rust CLI)
 - Golden vector enforcement
 - Behavioral parity with the Rust reference implementation
@@ -80,7 +81,7 @@ const value = parse(source);
 const scb = encodeValue(value); // Uint8Array (canonical bytes)
 
 // Hashing is defined over canonical bytes
-console.log(hashValueHex(scb));
+console.log(hashValueHex(value));
 ```
 
 ---
@@ -105,12 +106,10 @@ console.log(roundtrippedScb);
 ### Hash an existing Value
 
 ```js
-import { parse, encodeValue, hashValueHex } from "@emagjby/strata-js";
+import { parse, hashValueHex } from "@emagjby/strata-js";
 
 const value = parse("[1, 2, 3]");
-const bytes = encodeValue(value);
-
-console.log(hashValueHex(bytes));
+console.log(hashValueHex(value));
 ```
 
 ---
@@ -208,7 +207,7 @@ Commands:
 - `compile` – compile `.st` → canonical `.scb`
 - `decode` – decode `.scb` for inspection
 - `hash` – compute deterministic hash
-- `fmt` – parse and pretty-print `.st`
+- `fmt` – parse and pretty-print `.st` (or `.scb`)
 
 ### Compile
 
@@ -239,6 +238,14 @@ strata-js decode input.scb
 
 ```bash
 strata-js fmt input.st
+strata-js fmt input.scb
+```
+
+Format options:
+
+```bash
+strata-js fmt --format pretty input.st
+strata-js fmt --format ast input.st
 ```
 
 ### Exit codes

--- a/strata-js/package-lock.json
+++ b/strata-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@emagjby/strata-js",
-  "version": "0.4.0",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@emagjby/strata-js",
-      "version": "0.4.0",
+      "version": "0.4.4",
       "dependencies": {
         "@noble/hashes": "^2.0.1"
       },

--- a/strata-js/package.json
+++ b/strata-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emagjby/strata-js",
-  "version": "0.4.0",
+  "version": "0.4.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/strata-js/src/__tests__/cli_fmt.test.ts
+++ b/strata-js/src/__tests__/cli_fmt.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+const CLI_PATH = join(process.cwd(), "src", "cli.ts");
+
+test("cli fmt handles .scb inputs", () => {
+    const dir = mkdtempSync(join(tmpdir(), "strata-js-"));
+    const input = join(dir, "input.scb");
+
+    try {
+        writeFileSync(
+            input,
+            Buffer.from([
+                0x40, 0x01, 0x20, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
+                0x20, 0x04, 0x74, 0x65, 0x73, 0x74,
+            ]),
+        );
+
+        const result = spawnSync(
+            "npx",
+            ["tsx", CLI_PATH, "fmt", "--format", "pretty", input],
+            { encoding: "utf8" },
+        );
+
+        assert.equal(result.status, 0, result.stderr);
+        assert.ok(result.stdout.includes("options: \"test\""));
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});

--- a/strata-js/src/__tests__/value_factory.test.ts
+++ b/strata-js/src/__tests__/value_factory.test.ts
@@ -7,7 +7,9 @@ import {
     encodeValue,
     decodeValue,
     hashValue,
+    fmt,
 } from "../index.js";
+import { FormatOptions } from "../fmt.js";
 import type { Value } from "../value.js";
 
 test("old factory API (V.*) still works (regression)", () => {
@@ -133,4 +135,20 @@ test("encode/hash stability: helper-built values match manual equivalents", () =
 
     // Optional roundtrip sanity
     assert.deepEqual(decodeValue(builtBytes), decodeValue(manualBytes));
+});
+
+test("fmt pretty formats decoded scb values", () => {
+    const value = FactoryValue.mapOf(
+        ["options", FactoryValue.string("test")],
+        ["clear", FactoryValue.listOf(FactoryValue.int(1n), FactoryValue.int(2n))],
+    );
+
+    const bytes = encodeValue(value);
+    const decoded = decodeValue(bytes);
+    const formatted = fmt(FormatOptions.PRETTY, decoded);
+
+    assert.ok(formatted.startsWith("{\n"));
+    assert.ok(formatted.includes("options: \"test\""));
+    assert.ok(formatted.includes("clear: [1, 2]"));
+    assert.ok(formatted.endsWith("}\n") || formatted.endsWith("}"));
 });

--- a/strata-js/src/cli.ts
+++ b/strata-js/src/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 
 import fs from "node:fs";
 import process from "node:process";
@@ -12,6 +12,7 @@ import { DecodeError } from "./decode_error.js";
 import { ParseError } from "./parse_error.js";
 
 import { inspectValue } from "./inspect.js";
+import { fmt, FormatOptions } from "./fmt.js";
 
 function exitOk(): never {
     process.exit(0);
@@ -71,10 +72,15 @@ function cmdHash(input: string): void {
     console.log(hex(hashed));
 }
 
-function cmdFmt(input: string): void {
-    const source = fs.readFileSync(input, "utf8");
-    const parsedValue = parse(source);
-    console.log(JSON.stringify(inspectValue(parsedValue), null, 2));
+function cmdFmt(
+    input: string,
+    options: FormatOptions = FormatOptions.PRETTY,
+): void {
+    const value = input.endsWith(".scb")
+        ? decodeValue(fs.readFileSync(input))
+        : parse(fs.readFileSync(input, "utf8"));
+    const formatted = fmt(options, value);
+    console.log(formatted);
 }
 
 function main(): void {
@@ -110,22 +116,44 @@ function main(): void {
         }
 
         case "fmt": {
-            if (args.length !== 1) {
-                exitInvalid("usage: strata-js fmt <input.st>");
+            if (args.length < 1 || args.length > 3)
+                return exitInvalid("usage: strata-js fmt [format] <input.st>");
+            if (args.length === 2) {
+                return exitInvalid(
+                    "usage: --format [type] must be provided if format is provided",
+                );
             }
-            cmdFmt(args[0]!);
+            if (args.length === 1) {
+                cmdFmt(args[0]!);
+                return exitOk();
+            }
+
+            if (args[0] !== "--format") {
+                return exitInvalid(
+                    "usage: first argument must be --format if format is provided",
+                );
+            }
+
+            if (args[1] !== "pretty" && args[1] !== "ast") {
+                return exitInvalid("usage: format type must be one of: pretty, ast");
+            }
+
+            const format =
+                args[1] === "pretty" ? FormatOptions.PRETTY : FormatOptions.AST;
+
+            cmdFmt(args[2]!, format);
             return exitOk();
         }
 
         case "--help": {
             console.log(`
-                Strata CLI (JavaScript)
+Strata CLI (JavaScript)
 
-                Commands:
-                  compile <input.st> <output.scb>
-                  decode <input.scb>
-                  hash <input.st|input.scb>
-                  fmt <input.st>
+Commands:
+  compile <input.st> <output.scb>
+  decode <input.scb>
+  hash <input.st|input.scb>
+  fmt [format] <input.st>
             `);
             process.exit(0);
         }

--- a/strata-js/src/fmt.ts
+++ b/strata-js/src/fmt.ts
@@ -1,0 +1,94 @@
+import { Value } from "./value.js";
+
+export enum FormatOptions {
+    PRETTY = "PRETTY",
+    AST = "AST",
+}
+
+export function fmt(opts: FormatOptions, value: Value): string {
+    switch (opts) {
+        case FormatOptions.PRETTY: {
+            const f = new PrettyFmt();
+            f.value(value);
+            return f.out;
+        }
+        case FormatOptions.AST:
+            return prettyDebug(value);
+    }
+}
+
+class PrettyFmt {
+    out = "";
+    depth = 0;
+    indent = 2;
+
+    private pad(): string {
+        return " ".repeat(this.depth * this.indent);
+    }
+
+    value(v: Value): void {
+        switch (v.kind) {
+            case "null":
+                this.out += "null";
+                break;
+            case "bool":
+                this.out += String(v.value);
+                break;
+            case "int":
+                this.out += String(v.value);
+                break;
+            case "string":
+                this.out += `"${v.value}"`;
+                break;
+            case "bytes":
+                this.bytes(v.value);
+                break;
+            case "list":
+                this.list(v.value as Value[]);
+                break;
+            case "map":
+                this.map(v.value as Map<string, Value>);
+                break;
+        }
+    }
+
+    private bytes(bytes: Uint8Array): void {
+        this.out += "[";
+        for (const b of bytes) {
+            this.out += b.toString(16).padStart(2, "0");
+        }
+        this.out += "]";
+    }
+
+    private list(list: Value[]): void {
+        this.out += "[";
+        for (let i = 0; i < list.length; i++) {
+            this.value(list[i]!);
+            if (i + 1 !== list.length) this.out += ", ";
+        }
+        this.out += "]";
+    }
+
+    private map(map: Map<string, Value>): void {
+        this.out += "{\n";
+        this.depth += 1;
+
+        const entries = [...map.entries()].sort(([a], [b]) => a.localeCompare(b));
+
+        for (const [k, v] of entries) {
+            this.out += this.pad();
+            this.out += k;
+            this.out += ": ";
+            this.value(v);
+            this.out += "\n";
+        }
+
+        this.depth -= 1;
+        this.out += this.pad();
+        this.out += "}";
+    }
+}
+
+function prettyDebug(value: unknown): string {
+    return JSON.stringify(value, null, 2);
+}

--- a/strata-js/src/index.ts
+++ b/strata-js/src/index.ts
@@ -4,6 +4,7 @@ export { encodeValue } from "./encode.js";
 export { decodeValue } from "./decode.js";
 export { hashValueHex, hashBytes as hashValue } from "./hash.js";
 export { parse } from "./parser.js";
+export { fmt } from "./fmt.js";
 
 export { Value, V } from "./value_factory.js";
 export { V as ValueFactory } from "./value_factory.js";

--- a/strata-js/test.st
+++ b/strata-js/test.st
@@ -1,0 +1,4 @@
+{
+    options: "test"
+    clear: [1, 2, 3]
+}

--- a/strata-rs/Cargo.lock
+++ b/strata-rs/Cargo.lock
@@ -372,7 +372,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "strata-rs"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "assert_cmd",
  "blake3",

--- a/strata-rs/Cargo.toml
+++ b/strata-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-rs"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 license = "MIT"
 description = "Deterministic binary data format with canonical encoding"

--- a/strata-rs/README.md
+++ b/strata-rs/README.md
@@ -42,6 +42,7 @@ It provides:
 - Safe decoder with explicit, structured errors
 - Parser for Strata Text (`.st`)
 - Deterministic BLAKE3 hashing
+- Deterministic formatting (`fmt`)
 - Production-grade CLI
 - Golden vector enforcement
 - Reference semantics for all other implementations
@@ -73,7 +74,7 @@ Strata supports a **fixed, closed value model**:
 Value =
     Null
   | Bool(bool)
-  | Int
+  | Int(i64)
   | String
   | Bytes
   | List(Value*)
@@ -82,7 +83,7 @@ Value =
 
 Rules:
 
-- Integers are explicit (no floats, no implicit coercions)
+- Integers are signed 64-bit (no floats, no implicit coercions)
 - Strings are UTF-8
 - Map keys are strings only
 - Bytes are raw bytes
@@ -148,9 +149,9 @@ Rules include:
 Identical values always produce identical `.scb` bytes.
 
 ```rust
-use strata::encode::encode_value;
+use strata::encode::encode;
 
-let bytes = encode_value(&value)?;
+let bytes = encode(&value)?;
 ```
 
 ---
@@ -170,9 +171,9 @@ Decoding reveals reality.
 Encoding enforces truth.
 
 ```rust
-use strata::decode::decode_value;
+use strata::decode::decode;
 
-let value = decode_value(&bytes)?;
+let value = decode(&bytes)?;
 ```
 
 ---
@@ -188,9 +189,9 @@ BLAKE3-256(canonical_scb_bytes)
 Example:
 
 ```rust
-use strata::hash::hash_bytes;
+use strata::hash::hash_value;
 
-let hash = hash_bytes(&bytes);
+let hash = hash_value(&value);
 ```
 
 Hashes are stable across:
@@ -257,6 +258,14 @@ strata hash input.scb
 
 ```bash
 strata fmt input.st
+strata fmt input.scb
+```
+
+Format options:
+
+```bash
+strata fmt --format pretty input.st
+strata fmt --format ast input.st
 ```
 
 ---

--- a/strata-rs/src/bin/strata.rs
+++ b/strata-rs/src/bin/strata.rs
@@ -3,6 +3,7 @@ use std::fs;
 
 use strata::decode::decode;
 use strata::encode::encode;
+use strata::fmt::{FormatOptions, fmt};
 use strata::parser::parse;
 
 #[derive(Parser)]
@@ -40,9 +41,12 @@ enum Commands {
         input: String,
     },
 
-    /// Format Strata source (.st) into a readable AST format
+    /// Format Strata bytecode (.scb) into a human-readable format (e.g., "pretty" (.st), "ast")
     Fmt {
-        /// Input Strata source file (.st)
+        /// Format options (e.g., "pretty", "ast")
+        #[arg(long)]
+        format: Option<String>,
+        /// Input Strata bytecode file (.scb)
         input: String,
     },
 }
@@ -89,19 +93,37 @@ fn run() -> Result<(), strata::error::StrataError> {
         }
         Commands::Decode { input } => {
             let bytecode = fs::read(&input).map_err(strata::error::StrataError::Io)?;
-
             let ast = decode(&bytecode)?;
 
             println!("{:#?}", ast);
 
             Ok(())
         }
-        Commands::Fmt { input } => {
-            let source_text = fs::read_to_string(&input).map_err(strata::error::StrataError::Io)?;
+        Commands::Fmt { input, format } => {
+            let bytecode = if input.ends_with(".st") {
+                let source_text =
+                    fs::read_to_string(&input).map_err(strata::error::StrataError::Io)?;
+                let ast = parse(&source_text)?;
+                encode(&ast)?
+            } else {
+                fs::read(&input).map_err(strata::error::StrataError::Io)?
+            };
 
-            let ast = parse(&source_text)?;
+            let options = match format.as_deref() {
+                Some("pretty") => FormatOptions::PRETTY,
+                Some("ast") => FormatOptions::AST,
+                Some(other) => {
+                    eprintln!("error: unknown format option '{}'", other);
+                    eprintln!("valid options are: 'pretty', 'ast'");
+                    return Ok(());
+                }
+                None => FormatOptions::PRETTY,
+            };
 
-            println!("{:#?}", ast);
+            let ast = decode(&bytecode)?;
+
+            let formatted = fmt(options, &ast);
+            println!("{}", formatted);
 
             Ok(())
         }

--- a/strata-rs/src/fmt.rs
+++ b/strata-rs/src/fmt.rs
@@ -1,0 +1,90 @@
+use std::collections::BTreeMap;
+
+use crate::value::Value;
+
+#[derive(Clone, Copy)]
+pub enum FormatOptions {
+    PRETTY,
+    AST,
+}
+
+pub fn fmt(opts: FormatOptions, value: &Value) -> String {
+    match opts {
+        FormatOptions::PRETTY => {
+            let mut f = PrettyFmt {
+                out: String::new(),
+                depth: 0,
+                indent: 2,
+            };
+            f.value(value);
+            f.out
+        }
+        FormatOptions::AST => format!("{:#?}", value),
+    }
+}
+
+struct PrettyFmt {
+    out: String,
+    depth: usize,
+    indent: usize,
+}
+
+impl PrettyFmt {
+    fn pad(&self) -> String {
+        " ".repeat(self.depth * self.indent)
+    }
+
+    fn value(&mut self, value: &Value) {
+        match value {
+            Value::Null => self.out.push_str("null"),
+            Value::Bool(b) => self.out.push_str(&b.to_string()),
+            Value::Int(i) => self.out.push_str(&i.to_string()),
+            Value::String(s) => {
+                self.out.push('"');
+                self.out.push_str(s);
+                self.out.push('"')
+            }
+            Value::Bytes(b) => self.bytes(b),
+            Value::List(l) => self.list(l),
+            Value::Map(m) => self.map(m),
+        }
+    }
+
+    fn bytes(&mut self, bytes: &[u8]) {
+        self.out.push('[');
+        for byte in bytes {
+            self.out.push_str(&format!("{:02x}", byte));
+        }
+        self.out.push(']');
+    }
+
+    fn list(&mut self, list: &[Value]) {
+        self.out.push('[');
+
+        for (i, v) in list.iter().enumerate() {
+            self.value(v);
+            if i + 1 != list.len() {
+                self.out.push_str(", ");
+            }
+        }
+
+        self.out.push(']');
+    }
+
+    fn map(&mut self, map: &BTreeMap<String, Value>) {
+        self.out.push_str("{\n");
+        self.depth += 1;
+
+        for (k, v) in map.iter() {
+            self.out.push_str(&self.pad());
+            self.out.push_str(k);
+            self.out.push_str(": ");
+            self.value(v);
+            self.out.push('\n');
+        }
+
+        self.depth -= 1;
+        self.out.push_str(&self.pad());
+        self.out.push('}');
+    }
+}

--- a/strata-rs/src/fmt_tests.rs
+++ b/strata-rs/src/fmt_tests.rs
@@ -1,0 +1,92 @@
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::fmt::{fmt, FormatOptions};
+    use crate::value::Value;
+
+    #[test]
+    fn fmt_primitives() {
+        assert_eq!(fmt(FormatOptions::PRETTY, &Value::Null), "null");
+        assert_eq!(fmt(FormatOptions::PRETTY, &Value::Bool(true)), "true");
+        assert_eq!(fmt(FormatOptions::PRETTY, &Value::Int(42)), "42");
+    }
+
+    #[test]
+    fn fmt_string() {
+        let v = Value::String("hello".into());
+        assert_eq!(fmt(FormatOptions::PRETTY, &v), "\"hello\"");
+    }
+
+    #[test]
+    fn fmt_bytes() {
+        let v = Value::Bytes(vec![0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(fmt(FormatOptions::PRETTY, &v), "[deadbeef]");
+    }
+
+    #[test]
+    fn fmt_list() {
+        let v = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+
+        assert_eq!(fmt(FormatOptions::PRETTY, &v), "[1, 2, 3]");
+    }
+
+    #[test]
+    fn fmt_map_multiline() {
+        let mut map = BTreeMap::new();
+        map.insert("id".to_string(), Value::Int(42));
+        map.insert("active".to_string(), Value::Bool(true));
+
+        let v = Value::Map(map);
+
+        let expected = r#"{
+  active: true
+  id: 42
+}"#;
+
+        assert_eq!(fmt(FormatOptions::PRETTY, &v), expected);
+    }
+
+    #[test]
+    fn fmt_nested_structure() {
+        let mut inner = BTreeMap::new();
+        inner.insert("x".to_string(), Value::Int(1));
+
+        let mut outer = BTreeMap::new();
+        outer.insert("nested".to_string(), Value::Map(inner));
+
+        let v = Value::Map(outer);
+
+        let expected = r#"{
+  nested: {
+    x: 1
+  }
+}"#;
+
+        assert_eq!(fmt(FormatOptions::PRETTY, &v), expected);
+    }
+
+    #[test]
+    fn fmt_ast_mode() {
+        let v = Value::Int(7);
+
+        let output = fmt(FormatOptions::AST, &v);
+
+        assert!(output.contains("Int"));
+        assert!(output.contains("7"));
+    }
+
+    #[test]
+    fn fmt_is_deterministic() {
+        let mut map = BTreeMap::new();
+        map.insert("b".to_string(), Value::Int(2));
+        map.insert("a".to_string(), Value::Int(1));
+
+        let v = Value::Map(map);
+
+        let first = fmt(FormatOptions::PRETTY, &v);
+        let second = fmt(FormatOptions::PRETTY, &v);
+
+        assert_eq!(first, second);
+    }
+}

--- a/strata-rs/src/lib.rs
+++ b/strata-rs/src/lib.rs
@@ -4,6 +4,7 @@ pub mod value;
 pub mod decode;
 pub mod encode;
 pub mod error;
+pub mod fmt;
 pub mod framing;
 pub mod hash;
 pub mod lexer;
@@ -11,6 +12,7 @@ pub mod parser;
 
 mod decode_tests;
 mod encode_tests;
+mod fmt_tests;
 mod hash_tests;
 mod lexer_tests;
 mod macros_tests;

--- a/strata-rs/tests/cli.rs
+++ b/strata-rs/tests/cli.rs
@@ -1,5 +1,5 @@
-use assert_cmd::Command;
 use assert_cmd::cargo_bin_cmd;
+use assert_cmd::Command;
 use predicates::prelude::*;
 use std::path::PathBuf;
 
@@ -9,7 +9,7 @@ fn strata() -> Command {
 
 fn temp_file(name: &str) -> PathBuf {
     let mut p = std::env::temp_dir();
-    p.push(format!("strata_test_{}", name));
+    p.push(format!("strata_test_{}_{}", std::process::id(), name));
     p
 }
 
@@ -127,5 +127,66 @@ mod tests {
             .unwrap();
 
         assert!(!output.status.success());
+    }
+
+    #[test]
+    fn cli_fmt_st_pretty() {
+        let input = temp_file("fmt_input.st");
+
+        fs::write(
+            &input,
+            r#"
+        user {
+            id: 1
+        }
+        "#,
+        )
+        .unwrap();
+
+        strata()
+            .args(["fmt", input.to_str().unwrap()])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("id"));
+    }
+
+    #[test]
+    fn cli_fmt_scb_pretty() {
+        let input = temp_file("fmt_input.scb");
+
+        // Int(1) -> canonical bytes
+        fs::write(&input, vec![0x10, 0x01]).unwrap();
+
+        strata()
+            .args(["fmt", input.to_str().unwrap()])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("1"));
+    }
+
+    #[test]
+    fn cli_fmt_ast() {
+        let input = temp_file("fmt_ast.scb");
+
+        fs::write(&input, vec![0x10, 0x01]).unwrap();
+
+        strata()
+            .args(["fmt", "--format", "ast", input.to_str().unwrap()])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Int"));
+    }
+
+    #[test]
+    fn cli_fmt_invalid_format() {
+        let input = temp_file("fmt_invalid.scb");
+
+        fs::write(&input, vec![0x10, 0x01]).unwrap();
+
+        strata()
+            .args(["fmt", "--format", "invalid", input.to_str().unwrap()])
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("unknown format option"));
     }
 }


### PR DESCRIPTION
## Summary

Introduce a deterministic formatting layer for Strata values and expose it through the CLI.

This adds developer-experience tooling for inspecting `.st` and `.scb` values without affecting canonical encoding, hashing, or semantics. Both Rust and JavaScript implementations now support formatted output for debugging, inspection, and tooling.

## Changes

- Added `fmt` module in `strata-rs` with `FormatOptions` (`PRETTY`, `AST`)
- Added `fmt` CLI command supporting:
  - `.st` parsing
  - `.scb` decoding
  - `--format pretty`
  - `--format ast`
- Implemented deterministic pretty formatter for lists, maps, and bytes
- Added JavaScript parity formatter (`src/fmt.ts`)
- Updated JS CLI to support `.st` and `.scb` formatting
- Added Rust CLI tests:
  - `cli_fmt_st_pretty`
  - `cli_fmt_scb_pretty`
  - `cli_fmt_ast`
  - `cli_fmt_invalid_format`
- Added JS formatter tests and CLI coverage
- Improved temp file handling in CLI tests
- Updated documentation for Strata v0.4 DX improvements

Closes #3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deterministic formatting capability with PRETTY and AST format options for both Strata source (.st) and compiled bytecode (.scb) files via new fmt command

* **Documentation**
  * Updated README documentation across JavaScript and Rust implementations to reflect formatting features, usage examples, and API changes

* **Chores**
  * Version bumped to 0.4.4 across JavaScript and Rust packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->